### PR TITLE
Set RSA explicitly | refs #38669

### DIFF
--- a/mm_client/lib/ssh_tunnel.py
+++ b/mm_client/lib/ssh_tunnel.py
@@ -37,7 +37,7 @@ def get_ssh_public_key():
     else:
         logger.info('Creating new SSH key: "%s".', ssh_key_path)
         p = subprocess.Popen(
-            ['ssh-keygen', '-b', '4096', '-f', str(ssh_key_path), '-N', ''],
+            ['ssh-keygen', '-t', 'rsa', '-b', '4096', '-f', str(ssh_key_path), '-N', ''],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT


### PR DESCRIPTION
Since openssh 9.5p1 the default type is ed25519 which is not yet supported by MirisManager.

To avoid incompatibility and as RSA 4096 bits is secure we stay on RSA for now.

Ref:

    https://github.com/openssh/openssh-portable/commit/e1c284d60a928bcdd60bc575c6f9604663502770